### PR TITLE
chore(ci): run tests & cov report via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: circleci/node:8.11.4-jessie
+        working_directory: ~/pickpick
+        steps:
+            - checkout
+            - restore_cache:
+                  keys:
+                      - v1-dependencies-{{ checksum "package.json" }}
+                      # fallback to using the latest cache if no exact match is found
+                      - v1-dependencies-
+            - run:
+                  name: Install
+                  command: npm install
+            - save_cache:
+                  paths:
+                      - node_modules
+                  key: v1-dependencies-{{ checksum "package.json" }}
+            - run:
+                  name: Tests
+                  command: npm run test:ci
+            - store_test_results:
+                  path: ~/pickpick/results
+            - run:
+                  name: Report Coverage
+                  command: npm run report-coverage

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "extends": ["eslint:recommended"],
+    "env": {
+        "node": true
+    }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"semi": false,
+	"singleQuote": true,
+	"useTabs": true,
+	"tabWidth": 4
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An A/B testing engine
 
+[![CircleCI](https://img.shields.io/circleci/project/github/ironSource/pickpick.svg)](https://circleci.com/gh/ironSource/pickpick)
+[![Coverage Status](https://coveralls.io/repos/github/ironSource/pickpick/badge.svg?branch=master)](https://coveralls.io/github/ironSource/pickpick?branch=master)
+[![npm latest version](https://img.shields.io/npm/v/pickpick.svg)](https://www.npmjs.com/package/pickpick)
+
 To use this engine, create one or more experiments and stick them in a container. Each experiment is composed of a bunch of variations which are randomly picked/served to you. Once you obtain a variation, use it to render some content or make some sort of a decision.
 
 The container's job is to select the correct experiments for each `visitor` based on each experiment's targeting expression. Thusly, to get a variation one would call `pick()` twice, once on the container and once on the experiment.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,18 @@
   "description": "an A/B testing engine for the web",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/*"
+    "precommit": "lint-staged",
+    "format": "./node_modules/prettier-eslint-cli/dist/index.js --write '{lib,test,examples,proto}/**/*.js'",
+    "docs": "documentation readme index.js --section=API -g",
+    "test": "nyc mocha test/*",
+    "test:ci": "MOCHA_FILE=./results/test-results.xml nyc mocha test/* --reporter mocha-junit-reporter",
+    "report-coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "author": "Yaniv Kessler",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ironSource/pickpick.git"
+  },
   "license": "MIT",
   "dependencies": {
     "debug": "^2.6.8",
@@ -19,6 +28,20 @@
   },
   "devDependencies": {
     "chai": "^4.0.2",
-    "express": "^4.16.3"
+    "coveralls": "^3.0.2",
+    "documentation": "^8.1.2",
+    "express": "^4.16.3",
+    "husky": "^0.14.3",
+    "lint-staged": "^7.2.2",
+    "mocha": "^5.2.0",
+    "mocha-junit-reporter": "^1.18.0",
+    "nyc": "^12.0.2",
+    "prettier-eslint-cli": "^4.7.1"
+  },
+  "lint-staged": {
+    "*.js": [
+      "./node_modules/prettier-eslint-cli/dist/index.js --write '{lib,test,examples,proto}/**/*.js'",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
## Changes

- Add CircleCI 2.0 configuration. Build is [here](https://circleci.com/gh/ironSource/pickpick)
- Add `mocha-junit-reporter` for exporting tests results as XML for CircleCI test parsing and presenting in build summary
- Run mocha tests via nyc for Istanbul coverage
- Report coverage summary to [Coveralls](https://coveralls.io/github/ironSource/pickpick)
- Add eslint configuration
- ESLint & Format on pre-commit with [prettier](https://github.com/prettier/prettier)
- Add NPM, Coveralls & CircleCI badges to README
- Add `npm run docs` script command to update README with generated docs of [documentaionjs](https://documentation.js.org)